### PR TITLE
remove new line character in publish command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -149,7 +149,7 @@ runs:
 
         COMMAND="prism components:publish \
         --skip-on-signature-match \
-        --no-confirm \"
+        --no-confirm"
 
         if [ "${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}" = "false" ]; then
           COMMAND="$COMMAND --commitHash=${{ steps.commit-details.outputs.COMMIT_HASH }}"


### PR DESCRIPTION
There's a small typo in the component publish command that causes an error when this action is called. This removes the offending new line character.