### PR TITLE
add COMPONENT_PATH input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This GitHub Action publishes a component via Prismatic's Prism CLI.
 
 ## Inputs
 
+- **COMPONENT_PATH** (optional): The path to the component's index.ts/js file. If not provided, the root will be used.
+- **CUSTOMER_ID** (optional): The ID of the customer with which to associate the component.
 - **PRISMATIC_URL** (required): The target Prismatic API to publish to.
 - **PRISM_REFRESH_TOKEN** (required): The token granting access to the API at the PRISMATIC_URL provided.
-- **CUSTOMER_ID** (optional): The ID of the customer with which to associate the component.
 - **COMMENT** (optional): Any comments to associate with the component.
 - **SKIP_COMMIT_HASH_PUBLISH** (optional): Skip inclusion of commit hash in metadata. Default is `false`.
 - **SKIP_COMMIT_URL_PUBLISH** (optional): Skip inclusion of commit URL in metadata. Default is `false`.
@@ -21,6 +22,7 @@ To use this action in your workflow, add the following step configuration to you
   - name: <STEP NAME>
     uses: prismatic-io/component-publisher@v1.0
     with:
+      COMPONENT_PATH: src/my-component
       PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
       PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ The following steps are an example of preparing the component bundle prior to pu
 
   - name: Install dependencies
     run: npm install
+    working-directory: src/my-component
 
   - name: Build component bundle
     run: npm run build
+    working-directory: src/my-component
 ```
 
 ## Acquiring PRISM_REFRESH_TOKEN

--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,6 @@ runs:
             echo "| Source Directory      | ${{ inputs.COMPONENT_PATH }} |"
             echo "| Target Stack          | ${{ inputs.PRISMATIC_URL }} |"
             echo "| Commit Link           | ${{ steps.commit-details.outputs.COMMIT_URL }} |"
-            echo "| "
 
             if [ -n "${{ steps.pr-details.outputs.PR_URL }}" ]; then
               echo "| PR Link               | ${{ steps.pr-details.outputs.PR_URL }} |"

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   color: "blue"
 
 inputs:
+  COMPONENT_PATH:
+    description: "The path to the component's index.ts/js. If not provided, the root directory will be used."
+    required: false
   CUSTOMER_ID:
     description: "The ID of the customer with which to associate the component."
     required: false
@@ -150,6 +153,10 @@ runs:
       run: |
         source $GITHUB_WORKSPACE/logger.sh
 
+        if [ -n "${{ inputs.COMPONENT_PATH }}" ]; then
+          cd ${{ inputs.COMPONENT_PATH }}
+        fi
+
         COMMAND="prism components:publish \
         --skip-on-signature-match \
         --no-confirm"
@@ -203,8 +210,10 @@ runs:
             echo "### Component Published :rocket:"
             echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
             echo "| --------------------- | --------------- |"
+            echo "| Source Directory      | ${{ inputs.COMPONENT_PATH }} |"
             echo "| Target Stack          | ${{ inputs.PRISMATIC_URL }} |"
             echo "| Commit Link           | ${{ steps.commit-details.outputs.COMMIT_URL }} |"
+            echo "| "
 
             if [ -n "${{ steps.pr-details.outputs.PR_URL }}" ]; then
               echo "| PR Link               | ${{ steps.pr-details.outputs.PR_URL }} |"

--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,11 @@ runs:
             echo "### Component Published :rocket:"
             echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
             echo "| --------------------- | --------------- |"
-            echo "| Source Directory      | ${{ inputs.COMPONENT_PATH }} |"
+
+            if [ -n "${{ inputs.COMPONENT_PATH }}" ]; then
+              echo "| Source Directory      | ${{ inputs.COMPONENT_PATH }} |"
+            fi
+            
             echo "| Target Stack          | ${{ inputs.PRISMATIC_URL }} |"
             echo "| Commit Link           | ${{ steps.commit-details.outputs.COMMIT_URL }} |"
 


### PR DESCRIPTION
This adds a new input, `COMPONENT_PATH` to support publishing a component from a particular folder. This is useful for monorepos wherein multiple components are maintained.