### PR TITLE
add quotes around comment input for prism command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,7 +178,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.COMMENT }}" ]; then
-          COMMAND="$COMMAND --comment=${{ inputs.COMMENT }}"
+          COMMAND="$COMMAND --comment=\"${{ inputs.COMMENT }}\""
         fi
 
         if [ -n "${{ inputs.CUSTOMER_ID }}" ]; then


### PR DESCRIPTION
This fixes an issue where a comment passed to the action is not being quoted properly in the prism command. Adding escaped quotes to the command allows comments to be correctly passed to the publish command.