### PR TITLE
Bump versions, add PRISM_VERSION input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: "Skip inclusion of pull request url in metadata."
     required: false
     default: false
+  PRISM_VERSION:
+    description: "The version of the Prism CLI to install. Defaults to ^9."
+    required: false
+    default: "^9"
 
 runs:
   using: "composite"
@@ -95,7 +99,7 @@ runs:
     - name: Set up Node using Github Action
       uses: actions/setup-node@v4
       with:
-        node-version: "18.19.1"
+        node-version: "22"
 
     # Check for existence of required environment variables.
     - name: Check if PRISMATIC_URL is set
@@ -146,7 +150,7 @@ runs:
 
         if ! npm list -g @prismatic-io/prism &> /dev/null; then
           log $INFO "\U1F527 Prism CLI is not installed. Installing..."
-          npm install --global @prismatic-io/prism@^8.2.0
+          npm install --global @prismatic-io/prism@${{ inputs.PRISM_VERSION }}
         else
           log $INFO "Prism CLI is already installed."
         fi


### PR DESCRIPTION
Keeping component-publisher in line with integration-publisher: https://github.com/prismatic-io/integration-publisher/pull/15