### PR TITLE
Extract action steps into tested scripts; align CI tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,79 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
+      - name: Run lint + bats
+        run: mise run test
+
+  action-smoke:
+    # End-to-end exercise of the composite action against a stubbed `prism`.
+    # Catches wiring bugs in action.yml (env passthrough, action_path,
+    # input names, step output handoff) that the bats tests don't see
+    # because they hit the scripts directly.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stub prism on PATH
+        run: tests/install-stubs.sh
+      - name: Run the composite action
+        id: action
+        uses: ./
+        with:
+          PRISMATIC_URL: https://example.invalid
+          PRISM_REFRESH_TOKEN: fake-refresh-token
+          CUSTOMER_ID: cust_smoke
+          COMMENT: smoke comment
+      - name: Assert prism received the expected argv
+        run: tests/assert-prism-calls.sh
+      - name: Assert PUBLISH_SKIPPED output is "false"
+        env:
+          PUBLISH_SKIPPED: ${{ steps.action.outputs.PUBLISH_SKIPPED }}
+        run: |
+          if [[ "$PUBLISH_SKIPPED" != "false" ]]; then
+            echo "::error::expected PUBLISH_SKIPPED=false, got '$PUBLISH_SKIPPED'"
+            exit 1
+          fi
+
+  action-smoke-skip:
+    # Variant: prism returns the signature-match skip message. Verifies that
+    # publish.sh sets PUBLISH_SKIPPED=true and the action surfaces it.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stub prism on PATH
+        run: tests/install-stubs.sh
+      - name: Run the composite action
+        id: action
+        uses: ./
+        env:
+          PRISM_STUB_PUBLISH_STDOUT: "Package signatures match, skipping publish"
+        with:
+          PRISMATIC_URL: https://example.invalid
+          PRISM_REFRESH_TOKEN: fake-refresh-token
+      - name: Assert PUBLISH_SKIPPED output is "true"
+        env:
+          PUBLISH_SKIPPED: ${{ steps.action.outputs.PUBLISH_SKIPPED }}
+        run: |
+          if [[ "$PUBLISH_SKIPPED" != "true" ]]; then
+            echo "::error::expected PUBLISH_SKIPPED=true, got '$PUBLISH_SKIPPED'"
+            exit 1
+          fi

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,8 @@
+# Development
+
+Tool versions are pinned in `mise.toml`.
+
+```sh
+mise install
+mise run test     # lint + bats (matches CI)
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This GitHub Action publishes a component via Prismatic's Prism CLI.
 - **SKIP_COMMIT_URL_PUBLISH** (optional): Skip inclusion of commit URL in metadata. Default is `false`.
 - **SKIP_REPO_URL_PUBLISH** (optional): Skip inclusion of repository URL in metadata. Default is `false`.
 - **SKIP_PULL_REQUEST_URL_PUBLISH** (optional): Skip inclusion of pull request URL in metadata. Default is `false`.
+- **PRISM_VERSION** (optional): The version of the Prism CLI to install. Defaults to `^9`.
 
 ## Example Usage
 
@@ -21,7 +22,7 @@ To use this action in your workflow, add the following step configuration to you
 
 ```yaml
 - name: <STEP NAME>
-  uses: prismatic-io/component-publisher@v1.0
+  uses: prismatic-io/component-publisher@<LATEST_VERSION>
   with:
     COMPONENT_PATH: src/my-component
     PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
@@ -36,7 +37,7 @@ Optional inputs can be passed via the `with` block as desired.
 The following steps are an example of preparing the component bundle prior to publishing via this action.
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v5
 
 - name: Install dependencies
   run: npm install

--- a/action.yml
+++ b/action.yml
@@ -26,245 +26,90 @@ inputs:
   SKIP_COMMIT_HASH_PUBLISH:
     description: "Skip inclusion of commit hash in metadata."
     required: false
-    default: false
+    default: "false"
   SKIP_COMMIT_URL_PUBLISH:
     description: "Skip inclusion of commit url in metadata."
     required: false
-    default: false
+    default: "false"
   SKIP_REPO_URL_PUBLISH:
     description: "Skip inclusion of repository url in metadata."
     required: false
-    default: false
+    default: "false"
   SKIP_PULL_REQUEST_URL_PUBLISH:
     description: "Skip inclusion of pull request url in metadata."
     required: false
-    default: false
+    default: "false"
   PRISM_VERSION:
     description: "The version of the Prism CLI to install. Defaults to ^9."
     required: false
     default: "^9"
 
+outputs:
+  PUBLISH_SKIPPED:
+    description: "true if prism skipped the publish due to a signature match."
+    value: ${{ steps.prism-publish.outputs.PUBLISH_SKIPPED }}
+
 runs:
   using: "composite"
   steps:
-    - name: Set up logger and text colors
+    - name: Validate inputs
       shell: bash
-      run: |
-        echo "ERROR=\033[31m" >> $GITHUB_ENV
-        echo "INFO=\033[1;4;34;38;2;96;120;226m" >> $GITHUB_ENV
-        echo "COLOR_RESET=\033[0m" >> $GITHUB_ENV
-        echo 'log() { local color=$1; local message=$2; echo -e ${color}${message}${COLOR_RESET}; }' > $GITHUB_WORKSPACE/logger.sh
-
-    - name: Get commit details from 'github' context
-      id: commit-details
-      shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-        log $INFO "Getting commit details from context..."
-        echo "COMMIT_HASH=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
-        echo "COMMIT_URL=https://github.com/${{ github.repository }}/commit/${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
-
-    - name: Get PR details from Github CLI
-      id: pr-details
-      shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-        log $INFO "Getting PR details from Github CLI..."
-        PR_DETAILS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0]')
-        if [[ -z "$PR_DETAILS" ]]; then
-          log $INFO "No PRs associated with this commit."
-          echo "PR_NUMBER=" >> $GITHUB_OUTPUT
-          echo "PR_URL=" >> $GITHUB_OUTPUT
-        else
-          PR_NUMBER=$(echo $PR_DETAILS | jq -r '.number')
-          PR_URL=$(echo $PR_DETAILS | jq -r '.html_url')
-          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_OUTPUT
-          echo "PR_URL=${PR_URL}" >> $GITHUB_OUTPUT
-        fi
+      run: ${{ github.action_path }}/scripts/validate-inputs.sh
       env:
+        PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
+        PRISM_REFRESH_TOKEN: ${{ inputs.PRISM_REFRESH_TOKEN }}
+
+    - name: Resolve commit and PR details
+      id: scm
+      shell: bash
+      run: ${{ github.action_path }}/scripts/scm-details.sh
+      env:
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.sha }}
         GH_TOKEN: ${{ github.token }}
 
-    - name: Print source control details
-      shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-        log $INFO "The commit hash is ${{ steps.commit-details.outputs.COMMIT_HASH }}"
-        log $INFO "The commit url is ${{ steps.commit-details.outputs.COMMIT_URL }}"
-        if [ -n "${{ steps.pr-details.outputs.PR_URL }}" ]; then
-          log $INFO "The PR url is ${{ steps.pr-details.outputs.PR_URL }}"
-        fi
-
-    # Node may be installed in the parent workflow. This ensures the version is what Prism expects.
-    # This action will use a cached version if available.
-    - name: Set up Node using Github Action
-      uses: actions/setup-node@v4
+    - name: Set up Node
+      uses: actions/setup-node@v5
       with:
         node-version: "22"
 
-    # Check for existence of required environment variables.
-    - name: Check if PRISMATIC_URL is set
-      shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-        if [ -z "${{ inputs.PRISMATIC_URL }}" ]; then
-          log $ERROR "PRISMATIC_URL is not set"
-          exit 1
-        else
-          log $INFO "PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}"
-        fi
-
-    - name: Check if PRISM_REFRESH_TOKEN is set
-      shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-        if [ -z "${{ inputs.PRISM_REFRESH_TOKEN }}" ]; then
-          log $ERROR "PRISM_REFRESH_TOKEN is not set"
-          exit 1
-        fi
-
-    - name: Print logo to console once
-      if: ${{ !env.LOGO_SHOWN }}
-      shell: bash
-      run: |
-        echo -e "
-        \n
-        \033[38;2;12;193;144m            .+.             \033[38;2;73;74;167m                         .#-                                                   -#-            
-        \033[38;2;8;199;150m        .#\033[38;2;12;193;144m.##\033[38;2;10;195;152m+\033[38;2;10;195;152m#+           \033[38;2;73;74;167m                          -#+                                            ##.    -#+            
-        \033[38;2;14;190;146m         ###\033[38;2;28;168;164m#.\033[38;2;30;163;167m+\033[38;2;18;185;154m#+          \033[38;2;73;74;167m    ... .-+-.     ....-+- ...    .-+-.   ....-++.  .-+-.      .---..  ...##.... ...    .-++-.  
-        \033[38;2;16;187;148m         ##\033[38;2;28;168;164m+\033[38;2;32;161;166m+  \033[38;2;35;155;171m###         \033[38;2;73;74;167m    -#####++###.  +#####+ .##  +##++###  .####+######+###.  +###+###+ .#######. -#+  .###++###-
-        \033[38;2;17;185;150m        #- \033[38;2;32;161;166m+#+  \033[38;2;30;169;158m-\033[38;2;35;155;171m##         \033[38;2;73;74;167m   -##.     .##. +#+     .##  ##+.      .##.   +##.   .##.  .   ..##.   ##.    -#+ .##.    .. 
-        \033[38;2;19;182;152m      .##-\033[38;2;31;162;168m .###.\033[38;2;40;148;173m \033[38;2;40;148;174m-##.       \033[38;2;73;74;167m   -#+       ##- +#-     .##   -#####-  .##    -##    .##. -#####+##.   ##.    -#+ +##        
-        \033[38;2;20;180;154m     .##. \033[38;2;31;162;167m.##+\033[38;2;37;153;172m##. \033[38;2;46;140;175m.##.      \033[38;2;73;74;167m   -##-     .##. +#-     .##   .    ##+ .##    -##    .##. ##.   .##.   ##.    -#+ .##.    .. 
-        \033[38;2;22;177;156m    .##.\033[38;2;33;158;169m .##. \033[38;2;47;140;175m.##-\033[38;2;55;131;174m .##-     \033[38;2;73;74;167m   -#####+####.  +#-     .##  ########. .##    -##    .##. ####+####.   ###+#. -#+  .###++###-
-        \033[38;2;24;174;158m   -##.\033[38;2;36;155;171m  ###\033[38;2;44;143;175m###\033[38;2;49;137;174m###  \033[38;2;62;122;174m.#\033[38;2;62;122;174m#+     \033[38;2;73;74;167m  -## .-+-.     ...     ...    ..-.    ...    ...    ...   ..--. ...    .--.  ...     .-+-.  
-        \033[38;2;25;172;159m  +##                 \033[38;2;66;118;173m#\033[38;2;69;115;173m##    \033[38;2;73;74;167m  -##                                                                                        
-        \033[38;2;26;170;160m .+\033[38;2;31;164;161m#\033[38;2;34;161;162m#\033[38;2;37;158;163m#\033[38;2;38;156;163m#\033[38;2;39;154;163m#\033[38;2;41;151;164m#\033[38;2;42;149;164m#\033[38;2;45;146;165m#\033[38;2;46;144;165m#\033[38;2;48;142;166m#\033[38;2;49;141;166m#\033[38;2;50;140;166m#\033[38;2;52;138;167m#\033[38;2;53;136;167m#\033[38;2;56;132;168m#\033[38;2;57;130;168m#\033[38;2;60;126;169m#\033[38;2;61;124;169m#\033[38;2;65;119;173m#\033[38;2;71;112;173m#\033[38;2;71;112;173m#\033[38;2;64;120;170m#.  \033[38;2;73;74;167m   -#.  
-        \n
-        "
-        echo "LOGO_SHOWN=true" >> "$GITHUB_ENV"
-
     - name: Install Prism
       shell: bash
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-
-        if ! npm list -g @prismatic-io/prism &> /dev/null; then
-          log $INFO "\U1F527 Prism CLI is not installed. Installing..."
-          npm install --global @prismatic-io/prism@${{ inputs.PRISM_VERSION }}
-        else
-          log $INFO "Prism CLI is already installed."
-        fi
+      run: ${{ github.action_path }}/scripts/install-prism.sh
+      env:
+        PRISM_VERSION: ${{ inputs.PRISM_VERSION }}
 
     - name: Publish Component
       id: prism-publish
-      shell: bash {0}
-      run: |
-        source $GITHUB_WORKSPACE/logger.sh
-
-        if [ -n "${{ inputs.COMPONENT_PATH }}" ]; then
-          cd ${{ inputs.COMPONENT_PATH }}
-        fi
-
-        COMMAND="prism components:publish \
-        --skip-on-signature-match \
-        --no-confirm"
-
-        if [ "${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}" = "false" ]; then
-          COMMAND="$COMMAND --commitHash=${{ steps.commit-details.outputs.COMMIT_HASH }}"
-        fi
-
-        if [ "${{ inputs.SKIP_COMMIT_URL_PUBLISH }}" = "false" ]; then
-          COMMAND="$COMMAND --commitUrl=${{ steps.commit-details.outputs.COMMIT_URL }}"
-        fi
-
-        if [ "${{ inputs.SKIP_REPO_URL_PUBLISH }}" = "false" ]; then
-          COMMAND="$COMMAND --repoUrl=${{ github.repository }}"
-        fi
-
-        if [ "${{ inputs.SKIP_PULL_REQUEST_URL_PUBLISH }}" = "false" ]; then
-          COMMAND="$COMMAND --pullRequestUrl=${{ steps.pr-details.outputs.PR_URL }}"
-        fi
-
-        if [ -n "${{ inputs.COMMENT }}" ]; then
-          COMMAND="$COMMAND --comment=\"${{ inputs.COMMENT }}\""
-        fi
-
-        if [ -n "${{ inputs.CUSTOMER_ID }}" ]; then
-          COMMAND="$COMMAND --customer=${{ inputs.CUSTOMER_ID }}"
-        fi
-
-        log $INFO "Running command: $COMMAND"
-        OUTPUT=$(eval "$COMMAND" 2>&1)
-        if [ $? -ne 0 ]; then
-          log $ERROR "Prism publish command failed:"
-          echo "$OUTPUT"
-          exit 1
-        fi
-
-        echo "$OUTPUT"
-
-        if echo "$OUTPUT" | grep -q "Package signatures match, skipping publish"; then
-          echo "PUBLISH_SKIPPED=true" >> $GITHUB_OUTPUT
-        else
-          echo "PUBLISH_SKIPPED=false" >> $GITHUB_OUTPUT
-        fi
+      shell: bash
+      run: ${{ github.action_path }}/scripts/publish.sh
       env:
         PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
         PRISM_REFRESH_TOKEN: ${{ inputs.PRISM_REFRESH_TOKEN }}
         PRISMATIC_TENANT_ID: ${{ inputs.PRISMATIC_TENANT_ID }}
+        COMPONENT_PATH: ${{ inputs.COMPONENT_PATH }}
+        REPO: ${{ github.repository }}
+        COMMIT_HASH: ${{ steps.scm.outputs.COMMIT_HASH }}
+        COMMIT_URL: ${{ steps.scm.outputs.COMMIT_URL }}
+        PR_URL: ${{ steps.scm.outputs.PR_URL }}
+        CUSTOMER_ID: ${{ inputs.CUSTOMER_ID }}
+        COMMENT: ${{ inputs.COMMENT }}
+        SKIP_COMMIT_HASH_PUBLISH: ${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}
+        SKIP_COMMIT_URL_PUBLISH: ${{ inputs.SKIP_COMMIT_URL_PUBLISH }}
+        SKIP_REPO_URL_PUBLISH: ${{ inputs.SKIP_REPO_URL_PUBLISH }}
+        SKIP_PULL_REQUEST_URL_PUBLISH: ${{ inputs.SKIP_PULL_REQUEST_URL_PUBLISH }}
 
-    - name: Provide summary of action
+    - name: Summary
       shell: bash
-      run: |
-        if [ "${{ steps.prism-publish.outputs.PUBLISH_SKIPPED }}" = "true" ]; then
-          {
-            echo "### Component Not Published 🚫"
-            echo "#### A component with this signature is already published."
-          } >> "$GITHUB_STEP_SUMMARY"
-        else 
-          {
-            echo "### Component Published :rocket:"
-            echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
-            echo "| --------------------- | --------------- |"
-
-            if [ -n "${{ inputs.COMPONENT_PATH }}" ]; then
-              echo "| Source Directory      | ${{ inputs.COMPONENT_PATH }} |"
-            fi
-            
-            echo "| Target Stack          | ${{ inputs.PRISMATIC_URL }} |"
-
-            if [ -n "${{ inputs.PRISMATIC_TENANT_ID }}" ]; then
-              echo "| Tenant ID             | ${{ inputs.PRISMATIC_TENANT_ID }} |"
-            fi
-
-            echo "| Commit Link           | ${{ steps.commit-details.outputs.COMMIT_URL }} |"
-
-            if [ -n "${{ steps.pr-details.outputs.PR_URL }}" ]; then
-              echo "| PR Link               | ${{ steps.pr-details.outputs.PR_URL }} |"
-            fi
-
-            if [ "${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}" = "false" ]; then
-              echo "| Commit Hash Published | ✅ |"
-            else 
-              echo "| Commit Hash Published | ❌ |"
-            fi
-
-            if [ "${{ inputs.SKIP_COMMIT_URL_PUBLISH }}" = "false" ]; then
-              echo "| Commit Link Published | ✅ |"
-            else 
-              echo "| Commit Link Published | ❌ |"
-            fi
-
-            if [ "${{ inputs.SKIP_REPO_URL_PUBLISH }}" = "false" ]; then
-              echo "| Repository Link Published | ✅ |"
-            else 
-              echo "| Repository Link Published | ❌ |"
-            fi
-
-            if [ "${{ inputs.SKIP_PULL_REQUEST_URL_PUBLISH }}" = "false" ]; then
-              echo "| PR Link Published | ✅ |"
-            else 
-              echo "| PR Link Published | ❌ |"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-        fi
+      run: ${{ github.action_path }}/scripts/summary.sh
+      env:
+        PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
+        PRISMATIC_TENANT_ID: ${{ inputs.PRISMATIC_TENANT_ID }}
+        COMPONENT_PATH: ${{ inputs.COMPONENT_PATH }}
+        COMMIT_URL: ${{ steps.scm.outputs.COMMIT_URL }}
+        PR_URL: ${{ steps.scm.outputs.PR_URL }}
+        PUBLISH_SKIPPED: ${{ steps.prism-publish.outputs.PUBLISH_SKIPPED }}
+        SKIP_COMMIT_HASH_PUBLISH: ${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}
+        SKIP_COMMIT_URL_PUBLISH: ${{ inputs.SKIP_COMMIT_URL_PUBLISH }}
+        SKIP_REPO_URL_PUBLISH: ${{ inputs.SKIP_REPO_URL_PUBLISH }}
+        SKIP_PULL_REQUEST_URL_PUBLISH: ${{ inputs.SKIP_PULL_REQUEST_URL_PUBLISH }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,24 @@
+[tools]
+bats = "1.13.0"
+shellcheck = "0.11.0"
+actionlint = "1.7.7"
+
+[tasks.lint-shell]
+description = "Static-check shell scripts with shellcheck"
+run = "shellcheck scripts/*.sh tests/*.sh tests/stubs/*"
+
+[tasks.lint-actions]
+description = "Static-check workflow files with actionlint"
+run = "actionlint"
+
+[tasks.lint]
+description = "Run all linters"
+depends = ["lint-shell", "lint-actions"]
+
+[tasks.bats]
+description = "Run bats unit tests"
+run = "bats tests/"
+
+[tasks.test]
+description = "Run all checks (lint + bats)"
+depends = ["lint", "bats"]

--- a/scripts/install-prism.sh
+++ b/scripts/install-prism.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v prism >/dev/null 2>&1; then
+  echo "Prism CLI is already installed."
+  exit 0
+fi
+
+PRISM_VERSION="${PRISM_VERSION:-^9}"
+echo "Installing @prismatic-io/prism@$PRISM_VERSION..."
+npm install --global "@prismatic-io/prism@$PRISM_VERSION"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Build and run `prism components:publish` from environment variables.
+# Inputs are read from env — never interpolated into the shell by the
+# caller — so values containing shell metacharacters cannot break out
+# into command execution.
+#
+# PRISM_BIN overrides the prism executable for testing.
+
+set -uo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+PRISM_BIN="${PRISM_BIN:-prism}"
+COMPONENT_PATH="${COMPONENT_PATH:-}"
+
+if [[ -n "$COMPONENT_PATH" ]]; then
+  cd "$COMPONENT_PATH" || exit 1
+fi
+
+args=("components:publish" "--skip-on-signature-match" "--no-confirm")
+
+[[ "${SKIP_COMMIT_HASH_PUBLISH:-false}" == "false" && -n "${COMMIT_HASH:-}" ]] && args+=("--commitHash=$COMMIT_HASH")
+[[ "${SKIP_COMMIT_URL_PUBLISH:-false}" == "false" && -n "${COMMIT_URL:-}" ]] && args+=("--commitUrl=$COMMIT_URL")
+[[ "${SKIP_REPO_URL_PUBLISH:-false}" == "false" && -n "${REPO:-}" ]] && args+=("--repoUrl=$REPO")
+[[ "${SKIP_PULL_REQUEST_URL_PUBLISH:-false}" == "false" && -n "${PR_URL:-}" ]] && args+=("--pullRequestUrl=$PR_URL")
+[[ -n "${CUSTOMER_ID:-}" ]] && args+=("--customer=$CUSTOMER_ID")
+[[ -n "${COMMENT:-}" ]] && args+=("--comment=$COMMENT")
+
+output=$("$PRISM_BIN" "${args[@]}" 2>&1)
+status=$?
+
+if (( status != 0 )); then
+  echo "::error::prism components:publish failed (exit $status)"
+  echo "$output"
+  exit "$status"
+fi
+
+echo "$output"
+
+if grep -q "Package signatures match, skipping publish" <<<"$output"; then
+  echo "PUBLISH_SKIPPED=true" >> "$GITHUB_OUTPUT"
+else
+  echo "PUBLISH_SKIPPED=false" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/scm-details.sh
+++ b/scripts/scm-details.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Resolve the short commit hash, commit URL, and (if any) PR URL for the
+# current run, then write them to $GITHUB_OUTPUT for downstream steps.
+
+set -euo pipefail
+
+: "${REPO:?REPO is required}"
+: "${SHA:?SHA is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+short_sha="${SHA:0:7}"
+echo "COMMIT_HASH=$short_sha" >> "$GITHUB_OUTPUT"
+echo "COMMIT_URL=https://github.com/$REPO/commit/$short_sha" >> "$GITHUB_OUTPUT"
+
+pr_url=""
+pr_number=""
+if details=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0]' 2>/dev/null) \
+   && [[ -n "$details" ]]; then
+  pr_url=$(jq -r '.html_url' <<<"$details")
+  pr_number=$(jq -r '.number' <<<"$details")
+fi
+echo "PR_URL=$pr_url" >> "$GITHUB_OUTPUT"
+echo "PR_NUMBER=$pr_number" >> "$GITHUB_OUTPUT"

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+: "${PRISMATIC_URL:?PRISMATIC_URL is required}"
+
+skip_row() {
+  local label="$1" skip="$2"
+  if [[ "$skip" == "false" ]]; then
+    echo "| $label | ✅ |"
+  else
+    echo "| $label | ❌ |"
+  fi
+}
+
+if [[ "${PUBLISH_SKIPPED:-false}" == "true" ]]; then
+  {
+    echo "### Component Not Published 🚫"
+    echo "#### A component with this signature is already published."
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+{
+  echo "### Component Published :rocket:"
+  echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
+  echo "| --------------------- | --------------- |"
+
+  if [[ -n "${COMPONENT_PATH:-}" ]]; then
+    echo "| Source Directory      | $COMPONENT_PATH |"
+  fi
+
+  echo "| Target Stack          | $PRISMATIC_URL |"
+
+  if [[ -n "${PRISMATIC_TENANT_ID:-}" ]]; then
+    echo "| Tenant ID             | $PRISMATIC_TENANT_ID |"
+  fi
+
+  echo "| Commit Link           | ${COMMIT_URL:-} |"
+
+  if [[ -n "${PR_URL:-}" ]]; then
+    echo "| PR Link               | $PR_URL |"
+  fi
+
+  skip_row "Commit Hash Published" "${SKIP_COMMIT_HASH_PUBLISH:-false}"
+  skip_row "Commit Link Published" "${SKIP_COMMIT_URL_PUBLISH:-false}"
+  skip_row "Repository Link Published" "${SKIP_REPO_URL_PUBLISH:-false}"
+  skip_row "PR Link Published" "${SKIP_PULL_REQUEST_URL_PUBLISH:-false}"
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Validate required inputs before any expensive setup runs (Node install,
+# Prism install, etc.). Inputs are read from the environment so values
+# containing shell metacharacters cannot break out into command execution.
+
+set -euo pipefail
+
+fail=0
+
+if [[ -z "${PRISMATIC_URL:-}" ]]; then
+  echo "::error::PRISMATIC_URL is not set"
+  fail=1
+fi
+
+if [[ -z "${PRISM_REFRESH_TOKEN:-}" ]]; then
+  echo "::error::PRISM_REFRESH_TOKEN is not set"
+  fail=1
+fi
+
+(( fail == 0 ))

--- a/tests/assert-prism-calls.sh
+++ b/tests/assert-prism-calls.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Assert the stub prism captured an expected components:publish call
+# during the action-smoke CI job.
+
+set -euo pipefail
+shopt -s nullglob
+
+calls=("$RUNNER_TEMP"/prism-calls/*)
+if [[ ${#calls[@]} -eq 0 ]]; then
+  echo "::error::stub prism was not invoked"
+  exit 1
+fi
+
+publish_call=""
+for f in "${calls[@]}"; do
+  argv="$(tr '\0' '\n' < "$f")"
+  if grep -qx 'components:publish' <<<"$argv"; then
+    publish_call="$f"
+    break
+  fi
+done
+
+if [[ -z "$publish_call" ]]; then
+  echo "::error::no components:publish call captured"
+  for f in "${calls[@]}"; do
+    echo "--- $f"
+    tr '\0' '\n' < "$f"
+  done
+  exit 1
+fi
+
+argv="$(tr '\0' '\n' < "$publish_call")"
+echo "captured publish argv:"
+echo "$argv"
+
+grep -qx -- '--skip-on-signature-match' <<<"$argv"
+grep -qx -- '--no-confirm' <<<"$argv"
+grep -q  -- '--commitHash=' <<<"$argv"
+grep -q  -- '--commitUrl=' <<<"$argv"
+grep -qx -- '--repoUrl=prismatic-io/component-publisher' <<<"$argv"
+grep -qx -- '--customer=cust_smoke' <<<"$argv"
+grep -qx -- '--comment=smoke comment' <<<"$argv"

--- a/tests/install-stubs.sh
+++ b/tests/install-stubs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Install action-smoke stub binaries onto $GITHUB_PATH and prepare the
+# capture directory the stubs write to.
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required (run from a GitHub Actions runner)}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+stub_dir="$RUNNER_TEMP/bin"
+
+mkdir -p "$stub_dir" "$RUNNER_TEMP/prism-calls"
+install -m 0755 "$here/stubs/prism" "$stub_dir/prism"
+
+echo "$stub_dir" >> "$GITHUB_PATH"

--- a/tests/publish.bats
+++ b/tests/publish.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/publish.sh.
+#
+# Each test runs the script with a stub `prism` that records its argv to a
+# file and emits canned stdout, then asserts on the captured argv and step
+# output.
+
+setup() {
+  PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  ARGV_FILE="$WORKDIR/argv"
+  CWD_FILE="$WORKDIR/cwd"
+  CANARY="$WORKDIR/pwned"
+  GITHUB_OUTPUT="$WORKDIR/github_output"
+  : > "$GITHUB_OUTPUT"
+  export ARGV_FILE CWD_FILE GITHUB_OUTPUT
+
+  cat > "$WORKDIR/prism" <<'STUB'
+#!/usr/bin/env bash
+pwd > "$CWD_FILE"
+{ printf '%s\0' "$@"; } > "$ARGV_FILE"
+echo "Component published successfully."
+STUB
+  chmod +x "$WORKDIR/prism"
+  export PRISM_BIN="$WORKDIR/prism"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+captured_argv() {
+  tr '\0' '\n' < "$ARGV_FILE"
+}
+
+@test "publish emits components:publish with skip-on-signature-match and no-confirm" {
+  "$PROJECT_ROOT/scripts/publish.sh"
+
+  run captured_argv
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"components:publish"* ]]
+  [[ "$output" == *"--skip-on-signature-match"* ]]
+  [[ "$output" == *"--no-confirm"* ]]
+}
+
+@test "PUBLISH_SKIPPED=false on a normal publish" {
+  "$PROJECT_ROOT/scripts/publish.sh"
+  grep -qx 'PUBLISH_SKIPPED=false' "$GITHUB_OUTPUT"
+}
+
+@test "PUBLISH_SKIPPED=true when prism reports a signature match" {
+  cat > "$WORKDIR/prism" <<'STUB'
+#!/usr/bin/env bash
+echo "Package signatures match, skipping publish"
+STUB
+  chmod +x "$WORKDIR/prism"
+
+  PRISM_BIN="$WORKDIR/prism" GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  grep -qx 'PUBLISH_SKIPPED=true' "$GITHUB_OUTPUT"
+}
+
+@test "metadata flags are appended when SKIP_* are false" {
+  COMMIT_HASH=abc1234 \
+  COMMIT_URL=https://example.invalid/c/abc1234 \
+  REPO=owner/repo \
+  PR_URL=https://example.invalid/pull/9 \
+  SKIP_COMMIT_HASH_PUBLISH=false \
+  SKIP_COMMIT_URL_PUBLISH=false \
+  SKIP_REPO_URL_PUBLISH=false \
+  SKIP_PULL_REQUEST_URL_PUBLISH=false \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  run captured_argv
+  [[ "$output" == *"--commitHash=abc1234"* ]]
+  [[ "$output" == *"--commitUrl=https://example.invalid/c/abc1234"* ]]
+  [[ "$output" == *"--repoUrl=owner/repo"* ]]
+  [[ "$output" == *"--pullRequestUrl=https://example.invalid/pull/9"* ]]
+}
+
+@test "metadata flags are omitted when SKIP_* are true" {
+  COMMIT_HASH=abc1234 \
+  COMMIT_URL=https://example.invalid/c/abc1234 \
+  REPO=owner/repo \
+  PR_URL=https://example.invalid/pull/9 \
+  SKIP_COMMIT_HASH_PUBLISH=true \
+  SKIP_COMMIT_URL_PUBLISH=true \
+  SKIP_REPO_URL_PUBLISH=true \
+  SKIP_PULL_REQUEST_URL_PUBLISH=true \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  run captured_argv
+  [[ "$output" != *"--commitHash="* ]]
+  [[ "$output" != *"--commitUrl="* ]]
+  [[ "$output" != *"--repoUrl="* ]]
+  [[ "$output" != *"--pullRequestUrl="* ]]
+}
+
+@test "CUSTOMER_ID adds --customer flag" {
+  CUSTOMER_ID=cust_42 \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  run captured_argv
+  [[ "$output" == *"--customer=cust_42"* ]]
+}
+
+@test "COMMENT adds --comment flag" {
+  COMMENT="release notes" \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  run captured_argv
+  [[ "$output" == *"--comment=release notes"* ]]
+}
+
+@test "COMPONENT_PATH cds before invoking prism" {
+  mkdir -p "$WORKDIR/comp"
+  COMPONENT_PATH="$WORKDIR/comp" \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  grep -q "/comp\$" "$CWD_FILE"
+}
+
+@test "shell metacharacters in COMMENT do not execute" {
+  COMMENT="\$(touch $CANARY)" \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  [ ! -e "$CANARY" ]
+  run captured_argv
+  [[ "$output" == *"--comment=\$(touch $CANARY)"* ]]
+}
+
+@test "non-zero prism exit fails the script and surfaces output" {
+  cat > "$WORKDIR/prism" <<'STUB'
+#!/usr/bin/env bash
+echo "boom"
+exit 7
+STUB
+  chmod +x "$WORKDIR/prism"
+
+  run env PRISM_BIN="$WORKDIR/prism" GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    "$PROJECT_ROOT/scripts/publish.sh"
+
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"prism components:publish failed"* ]]
+  [[ "$output" == *"boom"* ]]
+  ! grep -q PUBLISH_SKIPPED "$GITHUB_OUTPUT"
+}

--- a/tests/stubs/prism
+++ b/tests/stubs/prism
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stub `prism` for action-smoke CI: captures argv to RUNNER_TEMP/prism-calls/.
+#
+# Behavior overrides for smoke job variants:
+#   PRISM_STUB_PUBLISH_STDOUT      stdout for components:publish (default success)
+#   PRISM_STUB_PUBLISH_EXIT        exit code for components:publish (default 0)
+
+out="$RUNNER_TEMP/prism-calls/$(date +%s%N)-$$"
+{ printf '%s\0' "$@"; } > "$out"
+
+echo "${PRISM_STUB_PUBLISH_STDOUT:-Component published successfully.}"
+exit "${PRISM_STUB_PUBLISH_EXIT:-0}"

--- a/tests/validate-inputs.bats
+++ b/tests/validate-inputs.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/validate-inputs.sh.
+
+setup() {
+  PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  REQUIRED=(
+    PRISMATIC_URL=https://example.invalid
+    PRISM_REFRESH_TOKEN=tok
+  )
+}
+
+@test "passes when required inputs are set" {
+  run env "${REQUIRED[@]}" "$PROJECT_ROOT/scripts/validate-inputs.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when PRISMATIC_URL is empty" {
+  run env "${REQUIRED[@]}" PRISMATIC_URL= "$PROJECT_ROOT/scripts/validate-inputs.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PRISMATIC_URL"* ]]
+}
+
+@test "fails when PRISM_REFRESH_TOKEN is empty" {
+  run env "${REQUIRED[@]}" PRISM_REFRESH_TOKEN= "$PROJECT_ROOT/scripts/validate-inputs.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PRISM_REFRESH_TOKEN"* ]]
+}


### PR DESCRIPTION
The goal is to make this project verifiable at CI-time and during local development. It also introduces a few config files, like dependabot, to keep dependencies fresh and aligned with the sibling integration-publisher repo.

The bash logic moves into separate scripts so shellcheck and bats can lint and exercise the steps this action takes.