### PR TITLE
Treat signature-match skip as neutral, surface component identifier

### DIFF
--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -13,16 +13,19 @@ skip_row() {
   fi
 }
 
+component_label="${COMPONENT_PATH:-.}"
+
 if [[ "${PUBLISH_SKIPPED:-false}" == "true" ]]; then
   {
-    echo "### Component Not Published 🚫"
-    echo "#### A component with this signature is already published."
+    echo "### Component Skipped :fast_forward:"
+    echo "#### \`$component_label\` is already up to date — signature matched the latest published version."
   } >> "$GITHUB_STEP_SUMMARY"
   exit 0
 fi
 
 {
   echo "### Component Published :rocket:"
+  echo "#### \`$component_label\`"
   echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
   echo "| --------------------- | --------------- |"
 

--- a/tests/summary.bats
+++ b/tests/summary.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/summary.sh.
+#
+# Each test runs the script with a temp GITHUB_STEP_SUMMARY file and the
+# minimum required env, then asserts on the captured markdown content.
+
+setup() {
+  PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  GITHUB_STEP_SUMMARY="$WORKDIR/summary.md"
+  : > "$GITHUB_STEP_SUMMARY"
+  export GITHUB_STEP_SUMMARY
+  export PRISMATIC_URL="https://example.invalid"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+@test "skipped publish uses neutral skip icon, not 🚫" {
+  PUBLISH_SKIPPED=true \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"🚫"* ]]
+  [[ "$output" != *"Component Not Published"* ]]
+  [[ "$output" == *":fast_forward:"* ]]
+  [[ "$output" == *"Component Skipped"* ]]
+}
+
+@test "skipped publish includes COMPONENT_PATH identifier" {
+  COMPONENT_PATH="components/slack" \
+  PUBLISH_SKIPPED=true \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"\`components/slack\`"* ]]
+}
+
+@test "skipped publish falls back to '.' when COMPONENT_PATH is unset" {
+  PUBLISH_SKIPPED=true \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"\`.\`"* ]]
+}
+
+@test "published summary includes COMPONENT_PATH in heading" {
+  COMPONENT_PATH="components/slack" \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"Component Published"* ]]
+  [[ "$output" == *"#### \`components/slack\`"* ]]
+}
+
+@test "published summary works without COMPONENT_PATH" {
+  "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Component Published"* ]]
+  [[ "$output" == *"#### \`.\`"* ]]
+}


### PR DESCRIPTION
Signature matches aren't a failure — they're a no-op. The 🚫 icon and "Component Not Published" heading made successful skip runs look like errors. Use ⏭️ and "Component Skipped", and include COMPONENT_PATH (or '.' when unset) in the heading so matrix runs show which component each summary refers to.